### PR TITLE
cpm_check_working_dir_is_clean for non git repo will not terminate cmake

### DIFF
--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -364,7 +364,7 @@ function(cpm_check_working_dir_is_clean repoPath isClean)
     RESULT_VARIABLE result
     OUTPUT_VARIABLE status
     OUTPUT_STRIP_TRAILING_WHITESPACE
-	ERROR_QUIET
+    ERROR_QUIET
     WORKING_DIRECTORY ${repoPath}
   )
 

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -355,41 +355,12 @@ function(cpm_parse_add_package_single_arg arg outArgs)
 endfunction()
 
 # Check that the working directory for a git repo is clean
-function(cpm_check_working_dir_is_clean repoPath gitTag isClean)
+function(cpm_check_git_working_dir_is_clean repoPath gitTag isClean)
 
   find_package(Git REQUIRED)
 
   if(NOT GIT_EXECUTABLE)
     # No git executable, assume directory is clean
-    set(${isClean}
-        TRUE
-        PARENT_SCOPE
-    )
-    return()
-  endif()
-
-  # get absolute path of .git dir, to find if we are in a top-level repo path
-  execute_process(
-    COMMAND ${GIT_EXECUTABLE} rev-parse --absolute-git-dir
-    RESULT_VARIABLE resultGitFolder
-    OUTPUT_VARIABLE gitFolderPath
-    OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET
-    WORKING_DIRECTORY ${repoPath}
-  )
-
-  if(resultGitFolder)
-    # Not a git repo. assume the directory is clean
-    set(${isClean}
-        TRUE
-        PARENT_SCOPE
-    )
-    return()
-  endif()
-
-  # remove trailing .git
-  get_filename_component(gitFolderPath "${gitFolderPath}" DIRECTORY)
-  if(NOT "${repoPath}" STREQUAL "${gitFolderPath}")
-    # edge case: not the repo base folder. maybe the cache is under a git repository. assume clean
     set(${isClean}
         TRUE
         PARENT_SCOPE
@@ -638,7 +609,7 @@ function(CPMAddPackage)
 
       if(DEFINED CPM_ARGS_GIT_TAG)
         # warn if cache has been changed since checkout
-        cpm_check_working_dir_is_clean(${download_directory} ${CPM_ARGS_GIT_TAG} IS_CLEAN)
+        cpm_check_git_working_dir_is_clean(${download_directory} ${CPM_ARGS_GIT_TAG} IS_CLEAN)
         if(NOT ${IS_CLEAN})
           message(WARNING "Cache for ${CPM_ARGS_NAME} (${download_directory}) is dirty")
         endif()

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -415,6 +415,14 @@ function(cpm_check_working_dir_is_clean repoPath gitTag isClean)
     return()
   endif()
 
+  if(NOT "${repoStatus}" STREQUAL "")
+    set(${isClean}
+        FALSE
+        PARENT_SCOPE
+    )
+    return()
+  endif()
+
   # check for commited changes
   execute_process(
     COMMAND ${GIT_EXECUTABLE} diff -s --exit-code ${gitTag}
@@ -423,7 +431,7 @@ function(cpm_check_working_dir_is_clean repoPath gitTag isClean)
     WORKING_DIRECTORY ${repoPath}
   )
 
-  if("${repoStatus}" STREQUAL "" AND ${resultGitDiff} EQUAL 0)
+  if(${resultGitDiff} EQUAL 0)
     set(${isClean}
         TRUE
         PARENT_SCOPE

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -355,7 +355,7 @@ function(cpm_parse_add_package_single_arg arg outArgs)
 endfunction()
 
 # Check that the working directory for a git repo is clean
-function(cpm_check_git_working_dir_is_clean repoPath isClean)
+function(cpm_check_working_dir_is_clean repoPath isClean)
   # Not sure this check is necessary given git is probably key to the rest of the script
   find_package(Git REQUIRED)
 
@@ -367,11 +367,11 @@ function(cpm_check_git_working_dir_is_clean repoPath isClean)
     WORKING_DIRECTORY ${repoPath}
   )
 
+  # Not a git repo. for now, assume the directory is clean
   if(result)
-    message(FATAL_ERROR "Calling git status on folder ${repoPath} failed")
-  endif()
-
-  if("${status}" STREQUAL "")
+    message(STATUS "${repoPath} is not a git repo, can't check if it's clean")
+    set(${isClean} TRUE PARENT_SCOPE)
+  elseif("${status}" STREQUAL "")
     set(${isClean} TRUE PARENT_SCOPE)
   else()
     set(${isClean} FALSE PARENT_SCOPE)
@@ -572,7 +572,7 @@ function(CPMAddPackage)
       set(${CPM_ARGS_NAME}_SOURCE_DIR ${download_directory})
 
       # warn if cache has been changed since checkout
-      cpm_check_git_working_dir_is_clean(${download_directory} IS_CLEAN)
+      cpm_check_working_dir_is_clean(${download_directory} IS_CLEAN)
       if(NOT ${IS_CLEAN})
         message(WARNING "Cache for ${CPM_ARGS_NAME} (${download_directory}) is dirty")
       endif()

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -388,8 +388,8 @@ function(cpm_check_working_dir_is_clean repoPath isClean)
   # remove trailing .git
   get_filename_component(gitFolderPath "${gitFolderPath}" DIRECTORY)
   if(NOT "${repoPath}" STREQUAL "${gitFolderPath}")
-    # edge case: not the repo base folder. maybe the cache is under a git repository assume clean
-	set(${isClean}
+    # edge case: not the repo base folder. maybe the cache is under a git repository. assume clean
+    set(${isClean}
         TRUE
         PARENT_SCOPE
     )

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -364,12 +364,13 @@ function(cpm_check_working_dir_is_clean repoPath isClean)
     RESULT_VARIABLE result
     OUTPUT_VARIABLE status
     OUTPUT_STRIP_TRAILING_WHITESPACE
+	ERROR_QUIET
     WORKING_DIRECTORY ${repoPath}
   )
 
   # Not a git repo. for now, assume the directory is clean
   if(result)
-    message(STATUS "${repoPath} is not a git repo, can't check if it's clean")
+    message(STATUS "not a git repo, can't check if clean:  ${repoPath}")
     set(${isClean} TRUE PARENT_SCOPE)
   elseif("${status}" STREQUAL "")
     set(${isClean} TRUE PARENT_SCOPE)

--- a/test/unit/dirty-cache-check.cmake
+++ b/test/unit/dirty-cache-check.cmake
@@ -8,7 +8,7 @@ find_package(Git REQUIRED)
 
 function(git_do dir)
   execute_process(
-    COMMAND ${GIT_EXECUTABLE} ${ARGN}
+    COMMAND ${GIT_EXECUTABLE}  -c user.name='User' -c user.email='user@email.org' ${ARGN}
     RESULT_VARIABLE result
     OUTPUT_VARIABLE status
     OUTPUT_STRIP_TRAILING_WHITESPACE

--- a/test/unit/dirty-cache-check.cmake
+++ b/test/unit/dirty-cache-check.cmake
@@ -1,0 +1,58 @@
+include(${CPM_PATH}/CPM.cmake)
+include(${CPM_PATH}/testing.cmake)
+
+set(baseDir "${CMAKE_CURRENT_BINARY_DIR}/test_dirty_cache")
+set(childDir "${baseDir}/edgecase")
+
+find_package(Git REQUIRED)
+
+function(git_do dir)
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} ${ARGN}
+    RESULT_VARIABLE result
+    OUTPUT_VARIABLE status
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    WORKING_DIRECTORY "${dir}"
+  )
+  if(result)
+    message(FATAL_ERROR "git ${ARGN} fail: ${result} ${status}")
+  endif()
+endfunction()
+
+file(MAKE_DIRECTORY "${baseDir}")
+
+file(WRITE "${baseDir}/draft.txt" "this is a test")
+message(STATUS "no git, a file")
+cpm_check_working_dir_is_clean(${baseDir} nogit_test)
+assert_truthy(nogit_test)
+
+git_do("${baseDir}" init -b main)
+message(STATUS "empty repo with file")
+cpm_check_working_dir_is_clean(${baseDir} emptygit_test)
+assert_falsy(emptygit_test)
+
+git_do("${baseDir}" add draft.txt)
+git_do("${baseDir}" commit -m "test change")
+message(STATUS "commit a change")
+cpm_check_working_dir_is_clean(${baseDir} onecommit_test)
+assert_truthy(onecommit_test)
+
+file(WRITE "${baseDir}/draft.txt" "a modification")
+message(STATUS "dirty repo")
+cpm_check_working_dir_is_clean(${baseDir} nonemptygit_test)
+assert_falsy(nonemptygit_test)
+
+git_do("${baseDir}" add draft.txt)
+git_do("${baseDir}" commit -m "another change")
+message(STATUS "repo clean")
+cpm_check_working_dir_is_clean(${baseDir} twocommit_test)
+assert_truthy(twocommit_test)
+
+file(MAKE_DIRECTORY "${childDir}")
+file(WRITE "${childDir}/draft.txt" "this in another test")
+message(STATUS "a sub dir")
+cpm_check_working_dir_is_clean(${childDir} edgecase_test)
+assert_truthy(edgecase_test)
+
+
+file(REMOVE_RECURSE "${baseDir}")

--- a/test/unit/dirty-cache-check.cmake
+++ b/test/unit/dirty-cache-check.cmake
@@ -2,7 +2,6 @@ include(${CPM_PATH}/CPM.cmake)
 include(${CPM_PATH}/testing.cmake)
 
 set(baseDir "${CMAKE_CURRENT_BINARY_DIR}/test_dirty_cache")
-set(childDir "${baseDir}/edgecase")
 
 find_package(Git REQUIRED)
 
@@ -26,31 +25,25 @@ file(WRITE "${baseDir}/draft.txt" "this is a test")
 git_do("${baseDir}" init -b main)
 git_do("${baseDir}" commit --allow-empty -m "empty repo")
 message(STATUS "empty repo with file")
-cpm_check_working_dir_is_clean(${baseDir} HEAD emptygit_test)
+cpm_check_git_working_dir_is_clean(${baseDir} HEAD emptygit_test)
 assert_falsy(emptygit_test)
 
 git_do("${baseDir}" add draft.txt)
 git_do("${baseDir}" commit -m "test change")
 git_do("${baseDir}" tag v0.0.0)
 message(STATUS "commit a change")
-cpm_check_working_dir_is_clean(${baseDir} v0.0.0 onecommit_test)
+cpm_check_git_working_dir_is_clean(${baseDir} v0.0.0 onecommit_test)
 assert_truthy(onecommit_test)
 
 file(WRITE "${baseDir}/draft.txt" "a modification")
 message(STATUS "dirty repo")
-cpm_check_working_dir_is_clean(${baseDir} v0.0.0 nonemptygit_test)
+cpm_check_git_working_dir_is_clean(${baseDir} v0.0.0 nonemptygit_test)
 assert_falsy(nonemptygit_test)
 
 git_do("${baseDir}" add draft.txt)
 git_do("${baseDir}" commit -m "another change")
 message(STATUS "repo clean")
-cpm_check_working_dir_is_clean(${baseDir} v0.0.0 twocommit_test)
+cpm_check_git_working_dir_is_clean(${baseDir} v0.0.0 twocommit_test)
 assert_falsy(twocommit_test)
-
-file(MAKE_DIRECTORY "${childDir}")
-file(WRITE "${childDir}/draft.txt" "this in another test")
-message(STATUS "a sub dir")
-cpm_check_working_dir_is_clean(${childDir} v0.0.0 edgecase_test)
-assert_truthy(edgecase_test)
 
 file(REMOVE_RECURSE "${baseDir}")

--- a/test/unit/dirty-cache-check.cmake
+++ b/test/unit/dirty-cache-check.cmake
@@ -8,7 +8,7 @@ find_package(Git REQUIRED)
 
 function(git_do dir)
   execute_process(
-    COMMAND ${GIT_EXECUTABLE}  -c user.name='User' -c user.email='user@email.org' ${ARGN}
+    COMMAND ${GIT_EXECUTABLE} -c user.name='User' -c user.email='user@email.org' ${ARGN}
     RESULT_VARIABLE result
     OUTPUT_VARIABLE status
     OUTPUT_STRIP_TRAILING_WHITESPACE
@@ -22,37 +22,35 @@ endfunction()
 file(MAKE_DIRECTORY "${baseDir}")
 
 file(WRITE "${baseDir}/draft.txt" "this is a test")
-message(STATUS "no git, a file")
-cpm_check_working_dir_is_clean(${baseDir} nogit_test)
-assert_truthy(nogit_test)
 
 git_do("${baseDir}" init -b main)
+git_do("${baseDir}" commit --allow-empty -m "empty repo")
 message(STATUS "empty repo with file")
-cpm_check_working_dir_is_clean(${baseDir} emptygit_test)
+cpm_check_working_dir_is_clean(${baseDir} HEAD emptygit_test)
 assert_falsy(emptygit_test)
 
 git_do("${baseDir}" add draft.txt)
 git_do("${baseDir}" commit -m "test change")
+git_do("${baseDir}" tag v0.0.0)
 message(STATUS "commit a change")
-cpm_check_working_dir_is_clean(${baseDir} onecommit_test)
+cpm_check_working_dir_is_clean(${baseDir} v0.0.0 onecommit_test)
 assert_truthy(onecommit_test)
 
 file(WRITE "${baseDir}/draft.txt" "a modification")
 message(STATUS "dirty repo")
-cpm_check_working_dir_is_clean(${baseDir} nonemptygit_test)
+cpm_check_working_dir_is_clean(${baseDir} v0.0.0 nonemptygit_test)
 assert_falsy(nonemptygit_test)
 
 git_do("${baseDir}" add draft.txt)
 git_do("${baseDir}" commit -m "another change")
 message(STATUS "repo clean")
-cpm_check_working_dir_is_clean(${baseDir} twocommit_test)
-assert_truthy(twocommit_test)
+cpm_check_working_dir_is_clean(${baseDir} v0.0.0 twocommit_test)
+assert_falsy(twocommit_test)
 
 file(MAKE_DIRECTORY "${childDir}")
 file(WRITE "${childDir}/draft.txt" "this in another test")
 message(STATUS "a sub dir")
-cpm_check_working_dir_is_clean(${childDir} edgecase_test)
+cpm_check_working_dir_is_clean(${childDir} v0.0.0 edgecase_test)
 assert_truthy(edgecase_test)
-
 
 file(REMOVE_RECURSE "${baseDir}")


### PR DESCRIPTION
I extended the function to handle non-git folders. I use CPM to download source archives, and the check would break there.
For now, is_check is just set to true, but maybe a fallback method can be found for these cases.